### PR TITLE
Field improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "nswdpc/silverstripe-elemental-iframe":"^0.2",
-        "fromholdio/silverstripe-externalurlfield": "~1.0"
+        "codem/silverstripe-html5-inputs": "^0.1",
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 | ^7",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "nswdpc/silverstripe-elemental-iframe":"^0.2",
-        "codem/silverstripe-html5-inputs": "^0.1",
+        "codem/silverstripe-html5-inputs": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 | ^7",

--- a/src/Models/Elements/ElementDatawrapper.php
+++ b/src/Models/Elements/ElementDatawrapper.php
@@ -181,6 +181,7 @@ class ElementDatawrapper extends ElementIframe {
         ]);
 
         $fields->insertAfter(
+            'Title',
             UrlField::create(
                 'InputURL',
                 _t(
@@ -191,8 +192,7 @@ class ElementDatawrapper extends ElementIframe {
             )->setDescription("In the format <code>https://datawrapper.dwcdn.net/abc12/1/</code>")
             ->setAttribute('pattern', 'https://datawrapper.dwcdn.net/abc12/1/')
             ->restrictToHttps()
-            ->setRequiredParts(['scheme','host','path']),
-            'Title'
+            ->setRequiredParts(['scheme','host','path'])
         );
 
         $webhook_url = WebhookController::getWebookURL();
@@ -200,6 +200,7 @@ class ElementDatawrapper extends ElementIframe {
             $fields->removeByName('AutoPublish');
         } else {
             $fields->insertAfter(
+                'InputURL',
                 CheckboxField::create(
                     'AutoPublish',
                     'Auto publish'
@@ -215,8 +216,7 @@ class ElementDatawrapper extends ElementIframe {
                             "url" => $webhook_url
                         ]
                     )
-                ),
-                'InputURL'
+                )
             );
         }
 

--- a/src/Models/Elements/ElementDatawrapper.php
+++ b/src/Models/Elements/ElementDatawrapper.php
@@ -23,7 +23,7 @@ class ElementDatawrapper extends ElementIframe {
 
     private static $icon = 'font-icon-code';
 
-    private static $inline_editable = true;
+    private static $inline_editable = false;
 
     private static $singular_name = 'Datawrapper element';
     private static $plural_name = 'Datawrapper elements';

--- a/src/Models/Elements/ElementDatawrapper.php
+++ b/src/Models/Elements/ElementDatawrapper.php
@@ -170,9 +170,12 @@ class ElementDatawrapper extends ElementIframe {
         $fields->insertAfter(
             UrlField::create(
                 'InputURL',
-                _t(__CLASS__ . ".DW_URL_NOT_EMBED_CODE", 'Datawrapper \'fullscreen share URL\' (not the embed code)'),
+                _t(
+                    __CLASS__ . ".DW_URL_LINK_TO_VISUALISATION",
+                    'The Datawrapper \'Link to your visualisation:\' URL (Visualisation only option)'
+                ),
                 $this->DatawrapperURL()
-            )->setDescription("In the format 'https://datawrapper.dwcdn.net/abc12/1/'")
+            )->setDescription("In the format <code>https://datawrapper.dwcdn.net/abc12/1/</code>")
             ->setAttribute('pattern', 'https://datawrapper.dwcdn.net/abc12/1/')
             ->restrictToHttps()
             ->setRequiredParts(['scheme','host','path']),
@@ -194,7 +197,7 @@ class ElementDatawrapper extends ElementIframe {
                         . "<br>"
                         . "The parent item of this element will not be published at the same time"
                         . "<br>"
-                        . "To enable this feature, please ensure the following URL is configured as a custom webhook in the relevant Team at Datawrapper<br><br>{url}",
+                        . "To enable this feature, please ensure the following URL is configured as a custom webhook in the relevant Team at Datawrapper: <code>{url}</code>",
                         [
                             "url" => $webhook_url
                         ]

--- a/src/Models/Elements/ElementDatawrapper.php
+++ b/src/Models/Elements/ElementDatawrapper.php
@@ -75,6 +75,7 @@ class ElementDatawrapper extends ElementIframe {
         $this->Width = "100%";// DW elements are always full width
         $this->IsResponsive = 1;//DW elements are always responsive
         $this->URLID = 0;// DW URLs are generated based on the provided embed URL, link module not used
+        $this->IsDynamic = 0;// iframe module turn off IsDynamic, DW provides its own.
         $this->setPartsFromUrl();
     }
 
@@ -168,6 +169,9 @@ class ElementDatawrapper extends ElementIframe {
     public function getCMSFields() {
         $fields = parent::getCMSFields();
         $fields->removeByName([
+            'URL',// link field
+            'URLID',// link field
+            'IsDynamic',// remove auto resize field from iframe
             'IsResponsive',
             'Width',// the item width cannot be changed, it is always 100%
             'IsFullWidth',// this item is always full width

--- a/src/Models/Elements/ElementDatawrapper.php
+++ b/src/Models/Elements/ElementDatawrapper.php
@@ -2,7 +2,7 @@
 
 namespace NSWDPC\Elemental\Models\Datawrapper;
 
-use BurnBright\ExternalURLField\ExternalURLField;
+use Codem\Utilities\HTML5\UrlField;
 use NSWDPC\Datawrapper\WebhookController;
 use NSWDPC\Elemental\Models\Iframe\ElementIframe;
 use SilverStripe\Forms\NumericField;
@@ -168,18 +168,14 @@ class ElementDatawrapper extends ElementIframe {
         ]);
 
         $fields->insertAfter(
-            ExternalURLField::create(
+            UrlField::create(
                 'InputURL',
                 _t(__CLASS__ . ".DW_URL_NOT_EMBED_CODE", 'Datawrapper \'fullscreen share URL\' (not the embed code)'),
                 $this->DatawrapperURL()
             )->setDescription("In the format 'https://datawrapper.dwcdn.net/abc12/1/'")
             ->setAttribute('pattern', 'https://datawrapper.dwcdn.net/abc12/1/')
-            ->setConfig([
-                'html5validation' => true,
-                'defaultparts' => [
-                    'scheme' => 'https'
-                ]
-            ])->setInputType('url'),
+            ->restrictToHttps()
+            ->setRequiredParts(['scheme','host','path']),
             'Title'
         );
 

--- a/src/Models/Elements/ElementDatawrapper.php
+++ b/src/Models/Elements/ElementDatawrapper.php
@@ -8,6 +8,7 @@ use NSWDPC\Elemental\Models\Iframe\ElementIframe;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\TextField;
+use SilverStripe\Forms\RequiredFields;
 use SilverStripe\ORM\ValidationException;
 use Silverstripe\View\ArrayData;
 use SilverStripe\View\Requirements;
@@ -152,6 +153,13 @@ class ElementDatawrapper extends ElementIframe {
     public function DatawrapperIdAttribute() {
         $id = "datawrapper-chart-{$this->DatawrapperId}";
         return $id;
+    }
+
+    /**
+     * Apply validator for CMS
+     */
+    public function getCMSValidator() {
+        return new RequiredFields('InputURL');
     }
 
     /**

--- a/src/Models/Elements/ElementDatawrapper.php
+++ b/src/Models/Elements/ElementDatawrapper.php
@@ -25,11 +25,11 @@ class ElementDatawrapper extends ElementIframe {
 
     private static $inline_editable = false;
 
-    private static $singular_name = 'Datawrapper element';
-    private static $plural_name = 'Datawrapper elements';
+    private static $singular_name = 'Datawrapper visualisation';
+    private static $plural_name = 'Datawrapper visualisations';
 
-    private static $title = 'Datawrapper element';
-    private static $description = 'Display Datawrapper content';
+    private static $title = 'Datawrapper visualisation';
+    private static $description = 'Display a Datawrapper visualisation';
 
     private static $default_host = 'datawrapper.dwcdn.net';
 
@@ -47,7 +47,7 @@ class ElementDatawrapper extends ElementIframe {
 
     public function getType()
     {
-        return _t(__CLASS__ . '.BlockType', 'Datawrapper');
+        return _t(__CLASS__ . '.BlockType', 'Datawrapper visualisation');
     }
 
     /**

--- a/src/Models/Elements/ElementDatawrapper.php
+++ b/src/Models/Elements/ElementDatawrapper.php
@@ -34,6 +34,7 @@ class ElementDatawrapper extends ElementIframe {
     private static $default_host = 'datawrapper.dwcdn.net';
 
     private static $db = [
+        'Content' => 'HTMLText',
         'DatawrapperId' => 'Varchar(5)',// dw IDs are 5 chr long
         'DatawrapperVersion' => 'Int',
         'AutoPublish' => 'Boolean',
@@ -216,6 +217,14 @@ class ElementDatawrapper extends ElementIframe {
                     )
                 ),
                 'InputURL'
+            );
+        }
+
+        $contentField = $fields->dataFieldByName('Content');
+        if($contentField) {
+            $fields->insertAfter(
+                'AutoPublish',
+                $contentField
             );
         }
 

--- a/templates/NSWDPC/Elemental/Models/Datawrapper/ElementDatawrapper.ss
+++ b/templates/NSWDPC/Elemental/Models/Datawrapper/ElementDatawrapper.ss
@@ -1,5 +1,8 @@
 <div class="content-element__content<% if $StyleVariant %> {$StyleVariant}<% end_if %>">
     <% include ElementDatawrapperTitle %>
+    <% if $Content %>
+    {$Content}
+    <% end_if %>
     <div class="outer">
         <% if $IsLazy %><noscript class="loading-lazy"><% end_if %>
             <iframe


### PR DESCRIPTION
## Changes

+ replace fromholdio/silverstripe-externalurlfield with codem/silverstripe-html5-inputs (UrlField)
+ NEW: add a Content field to describe the visualisation, apply to default template
+ Apply a RequiredField validator for the InputURL field
+ Make element NOT inline editable to work around validation inconsistencies
+ Remove unused fields inherited from `nswdpc/silverstripe-elemental-iframe`
+ Set IsDynamic=0, as DW provides its own responsive script
+ Update title and description of element to Datawrapper visualisation